### PR TITLE
Fixes a warning from an unsuitable format specifier

### DIFF
--- a/src/include/OpenImageIO/fmath.h
+++ b/src/include/OpenImageIO/fmath.h
@@ -2419,7 +2419,13 @@ inline OIIO_HOSTDEVICE float
 interpolate_linear (float x, span_strided<const float> y)
 {
 #ifndef __CUDA_ARCH__
-    DASSERT_MSG (y.size() >= 2, "interpolate_linear needs at least 2 knot values (%zd)", y.size());
+#ifdef OIIO_SPAN_SIZE_IS_UNSIGNED
+    // using oiio_span_size_type = size_t; => %zu is suitable
+    DASSERT_MSG (y.size() >= 2, "interpolate_linear needs at least 2 knot values (%zu)", y.size());
+#else
+    // using oiio_span_size_type = ptrdiff_t; => %td is suitable
+    DASSERT_MSG (y.size() >= 2, "interpolate_linear needs at least 2 knot values (%td)", y.size());
+#endif
 #endif
     x = clamp (x, float(0.0), float(1.0));
     int nsegs = int(y.size()) - 1;


### PR DESCRIPTION
## Description

`DASSERT_MSG` is was used with the format specifier `%zd` which is unsuitable for either of the options that `oiio_span_size_type` could evaluate to. This PR should fix it for both cases (`OIIO_SPAN_SIZE_IS_UNSIGNED` is defined and not defined) by using the appropriate format specifier in each case.

## Tests

Compiler warning is now gone.

## Checklist:

<!-- Put an 'x' in the boxes as you complete the checklist items -->

- [x] I have read the [contribution guidelines](https://github.com/OpenImageIO/oiio/blob/master/CONTRIBUTING.md).
- [ ] If this is more extensive than a small change to existing code, I
  have previously submitted a Contributor License Agreement
  ([individual](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-INDIVIDUAL), and if there is any way my
  employers might think my programming belongs to them, then also
  [corporate](https://github.com/OpenImageIO/oiio/blob/master/src/doc/CLA-CORPORATE)).
- [ ] I have updated the documentation, if applicable.
- [ ] I have ensured that the change is tested somewhere in the testsuite
  (adding new test cases if necessary).
- [x] My code follows the prevailing code style of this project.

